### PR TITLE
macos fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747533086,
-        "narHash": "sha256-+8goyptSXa7qV0k5uPKyky58jpBjI/qkzsbwCZFvhRY=",
+        "lastModified": 1747696584,
+        "narHash": "sha256-TvJjbLlQ5aAHS3ZdP8mztNs28cMGWdT3J9g/6li3/4I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8406224e30c258025cb8b31704bdb977a8f1f009",
+        "rev": "359c442b7d1f6229c1dc978116d32d6c07fe8440",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -46,12 +46,12 @@
           libtool
           llvmPackages_20.clang
           llvmPackages_20.clang-tools
-          mold-wrapped
           ninja
           pkg-config
           qt6.wrapQtAppsHook
         ]
         ++ lib.optionals isLinux [
+          mold-wrapped
           libsystemtap
           linuxPackages.bcc
           linuxPackages.bpftrace
@@ -67,7 +67,7 @@
           qrencode
           qt6.qtbase
           qt6.qttools
-          sqlite
+          sqlite.dev
           zeromq
         ]
         ++ lib.optionals isLinux [
@@ -102,7 +102,6 @@
           python312Packages.pyzmq
           python312Packages.vulture
           uv
-          valgrind
         ];
 
         inherit (env) CMAKE_GENERATOR LD_LIBRARY_PATH LOCALE_ARCHIVE QT_PLUGIN_PATH;


### PR DESCRIPTION
A few small changes:

- Move mold-wrapped under the isLinux conditional
- Take out valgrind (nix complained this pkg is broken)
- Specify sqlite.dev to include the correct header

To test, I compiled on macOS and verified I was able to run the resulting binaries `bitcoind` and `bitcoin-qt`. I also tested this flake on `linux-x86_64` to make sure I didn't break anything, but no issues. However, I did notice its not using mold as the linker, but unclear if that was broken before or if I broke it by moving mold-wrapped under the conditional. Seems unlikely that my change would have broken mold, so leaving as a follow-up for now.